### PR TITLE
CI: Add CI matrix entry to test summary report generation from wheel install

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -46,8 +46,7 @@ jobs:
       - name: Install pydarshan
         run: |
           cd darshan-util/pydarshan
-          # TODO: use pip per gh-476
-          python setup.py install
+          python -m pip install .
       # shim for importlib.resources on Python < 3.9
       - if: ${{matrix.python-version < 3.9}}
         name: Install importlib_resources
@@ -87,14 +86,3 @@ jobs:
         with:
           files: coverage.xml
           fail_ci_if_error: False
-      - name: Generate summary report from wheel install
-        run: |
-          export LD_LIBRARY_PATH=$PWD/darshan_install/lib
-          cd darshan-util/pydarshan
-          rm darshan/backend/apmpi.py
-          rm darshan/backend/apxc.py
-          python -m pip wheel . --no-deps
-          rm darshan/cli/base.html
-          rm darshan/cli/style.css
-          python -m pip install ./*.whl --no-deps --force-reinstall
-          python -m darshan summary tests/input/sample.darshan

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -93,5 +93,5 @@ jobs:
           cd darshan-util/pydarshan
           rm darshan/backend/apmpi.py
           rm darshan/backend/apxc.py
-          python -m pip install .
+          python -m pip install . --no-deps
           python -m darshan summary tests/input/sample.darshan

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade pytest mypy pyflakes asv pytest-cov codecov
+          python -m pip install --upgrade pytest mypy pyflakes asv pytest-cov codecov wheel
           # matplotlib is pinned because of
           # gh-479
           python -m pip install matplotlib==3.4.3
@@ -87,3 +87,11 @@ jobs:
         with:
           files: coverage.xml
           fail_ci_if_error: False
+      - name: Generate summary report from wheel install
+        run: |
+          export LD_LIBRARY_PATH=$PWD/darshan_install/lib
+          cd darshan-util/pydarshan
+          rm darshan/backend/apmpi.py
+          rm darshan/backend/apxc.py
+          python -m pip install .
+          python -m darshan summary tests/input/sample.darshan

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -93,5 +93,8 @@ jobs:
           cd darshan-util/pydarshan
           rm darshan/backend/apmpi.py
           rm darshan/backend/apxc.py
+          python -m pip wheel . --no-deps
+          rm darshan/cli/base.html
+          rm darshan/cli/style.css
           python -m pip install . --no-deps
           python -m darshan summary tests/input/sample.darshan

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -96,5 +96,5 @@ jobs:
           python -m pip wheel . --no-deps
           rm darshan/cli/base.html
           rm darshan/cli/style.css
-          python -m pip install ./*.whl
+          python -m pip install ./*.whl --no-deps --force-reinstall
           python -m darshan summary tests/input/sample.darshan

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -96,5 +96,5 @@ jobs:
           python -m pip wheel . --no-deps
           rm darshan/cli/base.html
           rm darshan/cli/style.css
-          python -m pip install . --no-deps
+          python -m pip install ./*.whl
           python -m darshan summary tests/input/sample.darshan

--- a/darshan-util/pydarshan/MANIFEST.in
+++ b/darshan-util/pydarshan/MANIFEST.in
@@ -1,4 +1,5 @@
 include README.rst
+include darshan/cli/style.css
 
 recursive-include tests *
 recursive-include darshan *.py

--- a/darshan-util/pydarshan/darshan/cli/summary.py
+++ b/darshan-util/pydarshan/darshan/cli/summary.py
@@ -179,7 +179,7 @@ def setup_parser(parser: argparse.ArgumentParser):
 
     """
     parser.description = "Generates a Darshan Summary Report"
-    
+
     parser.add_argument(
         "log_path",
         type=str,
@@ -215,11 +215,9 @@ def main(args: Union[Any, None] = None):
     # collect the report data to feed into the template
     report_data = ReportData(log_path=log_path)
 
-    with importlib_resources.path(darshan.cli, "") as path:
-        # get the path to the base template
-        base_path = os.path.join(str(path), "base.html")
+    with importlib_resources.path(darshan.cli, "base.html") as base_path:
         # load a template object using the base template
-        template = Template(filename=base_path)
+        template = Template(filename=str(base_path))
         # render the base template
         stream = template.render(report_data=report_data)
         with open(report_filename, "w") as f:

--- a/darshan-util/pydarshan/setup.py
+++ b/darshan-util/pydarshan/setup.py
@@ -10,7 +10,7 @@ with open("README.rst") as readme_file:
     readme = readme_file.read()
 
 
-requirements = ["cffi", "numpy", "pandas", "matplotlib", "seaborn"]
+requirements = ["cffi", "numpy", "pandas", "matplotlib", "seaborn", "mako"]
 setup_requirements = [
     "pytest-runner",
 ]


### PR DESCRIPTION
* Add `mako` to list of dependencies in `setup.py`

* Add a CI matrix entry which reinstalls PyDarshan via wheel
and runs command to generate summary report to check if .css
and .html assets are being included properly